### PR TITLE
Fix an issue on dot()

### DIFF
--- a/bytecode_graph/render.py
+++ b/bytecode_graph/render.py
@@ -47,7 +47,8 @@ class Render:
             blocks.append((prev, x))
             prev = None
 
-        blocks.append((prev, x))
+        if prev is not None:
+            blocks.append((prev, x))
         return blocks
 
     def get_edges(self, blocks):


### PR DESCRIPTION
bytecode_graph broke on this script

```python
import bytecode_graph 
from dis import opmap
import sys
import marshal

pyc_file = open(sys.argv[1], "rb").read()
pyc = marshal.loads(pyc_file[8:])
bcg = bytecode_graph.BytecodeGraph(pyc)
graph = bytecode_graph.Render(bcg, pyc).dot()
graph.write_png('example_graph.png')
```

Error info:

```python
Traceback (most recent call last):
  File "./gen_graph.py", line 9, in <module>
    graph = bytecode_graph.Render(bcg, pyc).dot()
  File "/tmp/flare-bytecode_graph/bytecode_gra/render.py", line 112, in dot
    lbl = disassemble(self.co, start=start.addr, stop=stop.addr+1,
AttributeError: 'NoneType' object has no attribute 'addr'
```

I've fixed this issue. : )
@joshuahoman

And this is test pyc file: [mo.zip](https://github.com/fireeye/flare-bytecode_graph/files/3541966/mo.zip)


